### PR TITLE
Chore/refactor and test core/phase1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+chatgpt-project-context.json
+chatgpt-project-context.md

--- a/tests/core.AppState.test.js
+++ b/tests/core.AppState.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import appState from "../core/services/AppState.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("AppState", () => {
+  beforeEach(() => {
+    // Reset l'état entre chaque test
+    appState._resetForTests();
+  });
+
+  it("getBotState() retourne l'état initial", () => {
+    const bot = appState.getBotState();
+    expect(bot.isReady).toBe(false);
+    expect(bot.isConnected).toBe(false);
+    expect(bot.commandsExecuted).toBe(0);
+    expect(bot.commandsFailed).toBe(0);
+  });
+
+  it("setBotReady(true) met à jour l'état", () => {
+    appState.setBotReady(true);
+    const bot = appState.getBotState();
+    expect(bot.isReady).toBe(true);
+    expect(typeof bot.startTime).toBe("number");
+  });
+
+  it("setBotConnected(true) met à jour l'état", () => {
+    appState.setBotConnected(true);
+    const bot = appState.getBotState();
+    expect(bot.isConnected).toBe(true);
+  });
+
+  it("incrementCommandsExecuted() incrémente le compteur", () => {
+    appState.incrementCommandsExecuted();
+    const bot = appState.getBotState();
+    expect(bot.commandsExecuted).toBe(1);
+  });
+
+  it("incrementCommandsFailed() incrémente le compteur", () => {
+    appState.incrementCommandsFailed();
+    const bot = appState.getBotState();
+    expect(bot.commandsFailed).toBe(1);
+  });
+
+  it("setDatabaseConnected(true) met à jour l'état", () => {
+    appState.setDatabaseConnected(true);
+    const db = appState.getDatabaseState();
+    expect(db.isConnected).toBe(true);
+    expect(typeof db.lastCheck).toBe("number");
+  });
+
+  it("setDatabaseHealthy(true) met à jour l'état", () => {
+    appState.setDatabaseHealthy(true);
+    const db = appState.getDatabaseState();
+    expect(db.isHealthy).toBe(true);
+    expect(typeof db.lastCheck).toBe("number");
+  });
+
+  it("isHealthy() retourne false si rien n'est prêt", () => {
+    const health = appState.isHealthy();
+    expect(health.overall).toBe(false);
+  });
+
+  it("isHealthy() retourne true si tout est prêt", () => {
+    appState.setBotReady(true);
+    appState.setBotConnected(true);
+    appState.setDatabaseConnected(true);
+    appState.setDatabaseHealthy(true);
+    appState.setApiRunning(true, 3000);
+    appState.setConfigLoaded({ NODE_ENV: "test" });
+    const health = appState.isHealthy();
+    expect(health.overall).toBe(true);
+  });
+
+  it("resetForTests() réinitialise tout", () => {
+    appState.setBotReady(true);
+    appState.setDatabaseConnected(true);
+    appState._resetForTests();
+    const bot = appState.getBotState();
+    const db = appState.getDatabaseState();
+    expect(bot.isReady).toBe(false);
+    expect(db.isConnected).toBe(false);
+  });
+});

--- a/tests/core.rateLimiter.test.js
+++ b/tests/core.rateLimiter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import rateLimiter, {
+  checkRateLimit,
+  recordCommand,
+  isUserBlocked,
+  unblockUser,
+  getRateLimitStats,
+} from "../core/utils/rateLimiter.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("rateLimiter", () => {
+  const userId = "user-test";
+  const commandType = "general";
+
+  beforeEach(() => {
+    rateLimiter.reset();
+  });
+
+  it("autorise les requêtes sous la limite", () => {
+    for (let i = 0; i < 5; i++) {
+      const res = checkRateLimit(userId, commandType);
+      expect(res.allowed).toBe(true);
+    }
+  });
+
+  it("bloque après avoir dépassé la limite", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    const res = checkRateLimit(userId, commandType);
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  it("isUserBlocked retourne true après blocage", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max + 1; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    expect(isUserBlocked(userId, commandType)).toBe(true);
+  });
+
+  it("unblockUser débloque l'utilisateur", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max + 1; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    expect(isUserBlocked(userId, commandType)).toBe(true);
+    unblockUser(userId, commandType);
+    expect(isUserBlocked(userId, commandType)).toBe(false);
+  });
+
+  it("reset() réinitialise toutes les limitations", () => {
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    rateLimiter.reset();
+    const stats = getRateLimitStats();
+    expect(stats.totalWindows).toBe(0);
+    expect(stats.totalBlocked).toBe(0);
+  });
+
+  it("getRateLimitStats retourne les stats correctes", () => {
+    checkRateLimit(userId, commandType);
+    const stats = getRateLimitStats();
+    expect(stats.totalWindows).toBeGreaterThanOrEqual(1);
+    expect(stats.commandStats[commandType]).toBeDefined();
+  });
+});

--- a/tests/core.retry.test.js
+++ b/tests/core.retry.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { RetryManager, retry } from "../core/utils/retry.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("RetryManager", () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new RetryManager({
+      maxAttempts: 3,
+      baseDelay: 1,
+      maxDelay: 5,
+      jitter: false,
+    });
+    // Mock sleep pour accélérer les tests
+    vi.spyOn(manager, "sleep").mockImplementation(() => Promise.resolve());
+  });
+
+  it("exécute une opération qui réussit du premier coup", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const res = await manager.execute(op);
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry sur erreur retryable puis succès", async () => {
+    const error = new Error("ECONNRESET");
+    error.code = "ECONNRESET";
+    const op = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("ok");
+    const res = await manager.execute(op);
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it("lance une erreur après maxAttempts", async () => {
+    const error = new Error("ECONNRESET");
+    error.code = "ECONNRESET";
+    const op = vi.fn().mockRejectedValue(error);
+    await expect(manager.execute(op)).rejects.toThrow("ECONNRESET");
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it("ne retry pas sur erreur non-retryable", async () => {
+    const error = new Error("FATAL");
+    error.code = "FATAL";
+    const op = vi.fn().mockRejectedValue(error);
+    await expect(manager.execute(op)).rejects.toThrow("FATAL");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepte des options custom", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const res = await manager.execute(op, { maxAttempts: 2 });
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retry (fonction utilitaire)", () => {
+  it("fonctionne comme prévu", async () => {
+    let count = 0;
+    const op = async () => {
+      count++;
+      if (count < 2)
+        throw Object.assign(new Error("ECONNRESET"), { code: "ECONNRESET" });
+      return "ok";
+    };
+    const res = await retry(op, {
+      maxAttempts: 3,
+      baseDelay: 1,
+      maxDelay: 5,
+      jitter: false,
+    });
+    expect(res).toBe("ok");
+  });
+});

--- a/tests/core.secureLogger.test.js
+++ b/tests/core.secureLogger.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { maskSensitiveData, secureLogger } from "../core/utils/secureLogger.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("secureLogger - maskSensitiveData", () => {
+  beforeEach(() => {
+    secureLogger.setSecurityLevel("medium");
+  });
+
+  it("masque les tokens", () => {
+    const msg = "token: 'abc12345678901234567890'";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[TOKEN_MASQUÉ]");
+  });
+
+  it("masque les emails", () => {
+    const msg = "Contact: test@example.com";
+    const masked = maskSensitiveData(msg, "medium", { maskEmails: true });
+    expect(masked).toContain("[EMAIL_MASQUÉ]");
+  });
+
+  it("masque les mots de passe", () => {
+    const msg = "password: 'supersecret'";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[MOT_DE_PASSE_MASQUÉ]");
+  });
+
+  it("masque les Discord IDs dans les contextes appropriés", () => {
+    const msg = "userId: 123456789012345678";
+    const masked = maskSensitiveData(msg, "medium", { maskIds: true });
+    expect(masked).toContain("[DISCORD_ID]");
+  });
+
+  it("ne masque pas les données non sensibles", () => {
+    const msg = "Ceci est un message normal.";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toBe(msg);
+  });
+
+  it("masque les URLs avec token", () => {
+    const msg = "https://example.com/api?token=abc123";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[URL_MASQUÉE]");
+  });
+
+  it("masque les IPs privées en production", () => {
+    // Simuler le contexte production
+    secureLogger.securityContext.isProduction = true;
+    const msg = "IP: 192.168.1.42";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[IP_MASQUÉE]");
+    // Reset
+    secureLogger.securityContext.isProduction = false;
+  });
+
+  it("masque les clés privées", () => {
+    const msg =
+      "-----BEGIN PRIVATE KEY-----\nABCDEF\n-----END PRIVATE KEY-----";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[CLÉ_PRIVÉE_MASQUÉE]");
+  });
+});


### PR DESCRIPTION
## **✅ Ajout de tests unitaires pour les modules critiques**
Cette PR ajoute une couverture de tests unitaires pour les modules fondamentaux du bot :

- `AppState` : tests des getters, setters, état de santé, et reset.
- `rateLimiter` : tests des limites, blocage/déblocage, reset, et statistiques.
- `retry` : tests du comportement du retry manager (succès, retry, échec, options custom).
- `secureLogger` : tests du masquage des données sensibles (tokens, emails, mots de passe, Discord IDs, URLs, IPs privées, clés privées).

### Points clés :

- Mock du logger pour éviter les effets de bord dans tous les tests.
- Les tests accélèrent les cycles de dev et sécurisent les évolutions futures.
- La couverture porte sur les cas courants, limites et les principaux scénarios d’erreur.