### PR TITLE
Chore/refactor and test core/phase1/units-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+chatgpt-project-context.json
+chatgpt-project-context.md

--- a/bot/commands/play.js
+++ b/bot/commands/play.js
@@ -18,23 +18,24 @@ export default {
     .setDMPermission(false),
 
   async execute (interaction) {
-    const { channel } = interaction.member.voice;
-
-    if (!channel) {
-      return interaction.reply({
-        content: '❌ Tu dois être dans un salon vocal ou Stage Channel.',
-        flags: MessageFlags.Ephemeral
-      });
-    }
-
-    if (channel.type !== ChannelType.GuildStageVoice) {
-      return interaction.reply({
-        content: '❌ Cette commande ne fonctionne que dans un Stage Channel.',
-        flags: MessageFlags.Ephemeral
-      });
-    }
-
     try {
+      const { voice } = interaction.member;
+      const channel = voice && voice.channel;
+
+      if (!channel) {
+        return interaction.reply({
+          content: '❌ Tu dois être dans un salon vocal ou Stage Channel.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+
+      if (channel.type !== ChannelType.GuildStageVoice) {
+        return interaction.reply({
+          content: '❌ Cette commande ne fonctionne que dans un Stage Channel.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+
       // ✅ Répond immédiatement pour éviter le timeout
       await interaction.deferReply();
 
@@ -62,7 +63,9 @@ export default {
 
       // 🔁 Sécurité si le stream prend trop de temps
       const timeout = setTimeout(() => {
-        interaction.editReply('⚠️ Aucun son détecté après 5s. Lecture échouée ?');
+        interaction.editReply(
+          '⚠️ Aucun son détecté après 5s. Lecture échouée ?'
+        );
       }, 5000);
 
       player.once(AudioPlayerStatus.Playing, async () => {
@@ -70,23 +73,28 @@ export default {
         await interaction.editReply('▶️ Stream lancé dans le stage channel.');
       });
 
-      player.on('error', async error => {
+      player.on('error', async (error) => {
         clearTimeout(timeout);
         logger.error('❌ Erreur du player:', error);
-        return await interaction.editReply('❌ Erreur pendant la lecture du stream.');
+        return await interaction.editReply(
+          '❌ Erreur pendant la lecture du stream.'
+        );
       });
     } catch (error) {
       logger.error('❌ Erreur exécution /play :', error);
       if (interaction.deferred || interaction.replied) {
         return await interaction.editReply({
-          content: '❌ Une erreur est survenue pendant la tentative de lecture.'
+          content:
+            '❌ Une erreur est survenue pendant la tentative de lecture.'
         });
       } else {
         return await interaction.reply({
-          content: '❌ Une erreur est survenue pendant la tentative de lecture.',
+          content:
+            '❌ Une erreur est survenue pendant la tentative de lecture.',
           flags: MessageFlags.Ephemeral
         });
       }
     }
   }
 };
+

--- a/bot/handlers/loadCommands.js
+++ b/bot/handlers/loadCommands.js
@@ -2,26 +2,26 @@
 // bot/handlers/loadCommands.js (ESM)
 // ========================================
 
-import fs from "node:fs";
-import path from "node:path";
-import { pathToFileURL, fileURLToPath } from "node:url";
-import logger from "../logger.js";
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import logger from '../logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function loadCommands(client, importFn = (src) => import(src)) {
+export async function loadCommands (client, importFn = (src) => import(src)) {
   try {
-    const commandsPath = path.join(__dirname, "../commands");
+    const commandsPath = path.join(__dirname, '../commands');
 
     if (!fs.existsSync(commandsPath)) {
-      logger.warn("Dossier commands introuvable.");
+      logger.warn('Dossier commands introuvable.');
       return { loaded: [], failed: [], total: 0 };
     }
 
-    const files = fs.readdirSync(commandsPath).filter((f) => f.endsWith(".js"));
+    const files = fs.readdirSync(commandsPath).filter((f) => f.endsWith('.js'));
 
     if (files.length) {
-      logger.section("Commandes");
+      logger.section('Commandes');
     }
 
     const loadedCommands = [];
@@ -29,18 +29,18 @@ export async function loadCommands(client, importFn = (src) => import(src)) {
 
     for (const file of files) {
       const filePath = path.join(commandsPath, file);
-      logger.debug("loadCommands: importing", filePath);
+      logger.debug('loadCommands: importing', filePath);
 
       try {
         const fileModule = await importFn(pathToFileURL(filePath).href);
 
         if (
-          fileModule.default?.data?.name &&
-          typeof fileModule.default.execute === "function"
+          fileModule.default?.data?.name
+          && typeof fileModule.default.execute === 'function'
         ) {
           client.commands.set(fileModule.default.data.name, fileModule.default);
           logger.custom(
-            "CMD",
+            'CMD',
             `Commande chargée : ${fileModule.default.data.name}`
           );
           loadedCommands.push(fileModule.default.data.name);
@@ -62,7 +62,7 @@ export async function loadCommands(client, importFn = (src) => import(src)) {
     return {
       loaded: loadedCommands,
       failed: failedCommands,
-      total: files.length,
+      total: files.length
     };
   } catch (err) {
     logger.error(`Erreur lors du chargement des commandes : ${err.message}`);

--- a/bot/handlers/loadCommands.js
+++ b/bot/handlers/loadCommands.js
@@ -2,26 +2,26 @@
 // bot/handlers/loadCommands.js (ESM)
 // ========================================
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { pathToFileURL, fileURLToPath } from 'node:url';
-import logger from '../logger.js';
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import logger from "../logger.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function loadCommands (client) {
+export async function loadCommands(client, importFn = (src) => import(src)) {
   try {
-    const commandsPath = path.join(__dirname, '../commands');
+    const commandsPath = path.join(__dirname, "../commands");
 
     if (!fs.existsSync(commandsPath)) {
-      logger.warn('Dossier commands introuvable.');
+      logger.warn("Dossier commands introuvable.");
       return { loaded: [], failed: [], total: 0 };
     }
 
-    const files = fs.readdirSync(commandsPath).filter((f) => f.endsWith('.js'));
+    const files = fs.readdirSync(commandsPath).filter((f) => f.endsWith(".js"));
 
     if (files.length) {
-      logger.section('Commandes');
+      logger.section("Commandes");
     }
 
     const loadedCommands = [];
@@ -29,18 +29,18 @@ export async function loadCommands (client) {
 
     for (const file of files) {
       const filePath = path.join(commandsPath, file);
-      logger.debug('loadCommands: importing', filePath);
+      logger.debug("loadCommands: importing", filePath);
 
       try {
-        const fileModule = await import(pathToFileURL(filePath).href);
+        const fileModule = await importFn(pathToFileURL(filePath).href);
 
         if (
-          fileModule.default?.data?.name
-          && typeof fileModule.default.execute === 'function'
+          fileModule.default?.data?.name &&
+          typeof fileModule.default.execute === "function"
         ) {
           client.commands.set(fileModule.default.data.name, fileModule.default);
           logger.custom(
-            'CMD',
+            "CMD",
             `Commande chargée : ${fileModule.default.data.name}`
           );
           loadedCommands.push(fileModule.default.data.name);
@@ -62,10 +62,11 @@ export async function loadCommands (client) {
     return {
       loaded: loadedCommands,
       failed: failedCommands,
-      total: files.length
+      total: files.length,
     };
   } catch (err) {
     logger.error(`Erreur lors du chargement des commandes : ${err.message}`);
     return { loaded: [], failed: [], total: 0 };
   }
 }
+

--- a/bot/handlers/loadEvents.js
+++ b/bot/handlers/loadEvents.js
@@ -2,26 +2,26 @@
 // bot/handlers/loadEvents.js (ESM)
 // ========================================
 
-import fs from "node:fs";
-import path from "node:path";
-import { pathToFileURL, fileURLToPath } from "node:url";
-import logger from "../logger.js";
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import logger from '../logger.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function loadEvents(client, importFn = (src) => import(src)) {
+export async function loadEvents (client, importFn = (src) => import(src)) {
   try {
-    const eventsPath = path.join(__dirname, "../events");
+    const eventsPath = path.join(__dirname, '../events');
 
     if (!fs.existsSync(eventsPath)) {
-      logger.warn("Dossier events introuvable.");
+      logger.warn('Dossier events introuvable.');
       return { loaded: [], failed: [], total: 0 };
     }
 
-    const files = fs.readdirSync(eventsPath).filter((f) => f.endsWith(".js"));
+    const files = fs.readdirSync(eventsPath).filter((f) => f.endsWith('.js'));
 
     if (files.length) {
-      logger.section("Événements");
+      logger.section('Événements');
     }
 
     const loadedEvents = [];
@@ -29,14 +29,14 @@ export async function loadEvents(client, importFn = (src) => import(src)) {
 
     for (const file of files) {
       const filePath = path.join(eventsPath, file);
-      logger.debug("loadEvents: importing", filePath);
+      logger.debug('loadEvents: importing', filePath);
 
       try {
         const fileModule = await importFn(pathToFileURL(filePath).href);
 
         if (
-          fileModule.default?.name &&
-          typeof fileModule.default.execute === "function"
+          fileModule.default?.name
+          && typeof fileModule.default.execute === 'function'
         ) {
           const handler = (...args) =>
             fileModule.default.execute(...args, client);
@@ -48,7 +48,7 @@ export async function loadEvents(client, importFn = (src) => import(src)) {
           }
 
           logger.custom(
-            "EVENTS",
+            'EVENTS',
             `Événement chargé : ${fileModule.default.name}`
           );
           loadedEvents.push(fileModule.default.name);
@@ -70,7 +70,7 @@ export async function loadEvents(client, importFn = (src) => import(src)) {
     return {
       loaded: loadedEvents,
       failed: failedEvents,
-      total: files.length,
+      total: files.length
     };
   } catch (err) {
     logger.error(`Erreur lors du chargement des événements : ${err.message}`);

--- a/tests/core.AppState.test.js
+++ b/tests/core.AppState.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import appState from "../core/services/AppState.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("AppState", () => {
+  beforeEach(() => {
+    // Reset l'état entre chaque test
+    appState._resetForTests();
+  });
+
+  it("getBotState() retourne l'état initial", () => {
+    const bot = appState.getBotState();
+    expect(bot.isReady).toBe(false);
+    expect(bot.isConnected).toBe(false);
+    expect(bot.commandsExecuted).toBe(0);
+    expect(bot.commandsFailed).toBe(0);
+  });
+
+  it("setBotReady(true) met à jour l'état", () => {
+    appState.setBotReady(true);
+    const bot = appState.getBotState();
+    expect(bot.isReady).toBe(true);
+    expect(typeof bot.startTime).toBe("number");
+  });
+
+  it("setBotConnected(true) met à jour l'état", () => {
+    appState.setBotConnected(true);
+    const bot = appState.getBotState();
+    expect(bot.isConnected).toBe(true);
+  });
+
+  it("incrementCommandsExecuted() incrémente le compteur", () => {
+    appState.incrementCommandsExecuted();
+    const bot = appState.getBotState();
+    expect(bot.commandsExecuted).toBe(1);
+  });
+
+  it("incrementCommandsFailed() incrémente le compteur", () => {
+    appState.incrementCommandsFailed();
+    const bot = appState.getBotState();
+    expect(bot.commandsFailed).toBe(1);
+  });
+
+  it("setDatabaseConnected(true) met à jour l'état", () => {
+    appState.setDatabaseConnected(true);
+    const db = appState.getDatabaseState();
+    expect(db.isConnected).toBe(true);
+    expect(typeof db.lastCheck).toBe("number");
+  });
+
+  it("setDatabaseHealthy(true) met à jour l'état", () => {
+    appState.setDatabaseHealthy(true);
+    const db = appState.getDatabaseState();
+    expect(db.isHealthy).toBe(true);
+    expect(typeof db.lastCheck).toBe("number");
+  });
+
+  it("isHealthy() retourne false si rien n'est prêt", () => {
+    const health = appState.isHealthy();
+    expect(health.overall).toBe(false);
+  });
+
+  it("isHealthy() retourne true si tout est prêt", () => {
+    appState.setBotReady(true);
+    appState.setBotConnected(true);
+    appState.setDatabaseConnected(true);
+    appState.setDatabaseHealthy(true);
+    appState.setApiRunning(true, 3000);
+    appState.setConfigLoaded({ NODE_ENV: "test" });
+    const health = appState.isHealthy();
+    expect(health.overall).toBe(true);
+  });
+
+  it("resetForTests() réinitialise tout", () => {
+    appState.setBotReady(true);
+    appState.setDatabaseConnected(true);
+    appState._resetForTests();
+    const bot = appState.getBotState();
+    const db = appState.getDatabaseState();
+    expect(bot.isReady).toBe(false);
+    expect(db.isConnected).toBe(false);
+  });
+});

--- a/tests/core.rateLimiter.test.js
+++ b/tests/core.rateLimiter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import rateLimiter, {
+  checkRateLimit,
+  recordCommand,
+  isUserBlocked,
+  unblockUser,
+  getRateLimitStats,
+} from "../core/utils/rateLimiter.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("rateLimiter", () => {
+  const userId = "user-test";
+  const commandType = "general";
+
+  beforeEach(() => {
+    rateLimiter.reset();
+  });
+
+  it("autorise les requêtes sous la limite", () => {
+    for (let i = 0; i < 5; i++) {
+      const res = checkRateLimit(userId, commandType);
+      expect(res.allowed).toBe(true);
+    }
+  });
+
+  it("bloque après avoir dépassé la limite", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    const res = checkRateLimit(userId, commandType);
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  it("isUserBlocked retourne true après blocage", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max + 1; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    expect(isUserBlocked(userId, commandType)).toBe(true);
+  });
+
+  it("unblockUser débloque l'utilisateur", () => {
+    const max = rateLimiter.configs[commandType].maxRequests;
+    for (let i = 0; i < max + 1; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    expect(isUserBlocked(userId, commandType)).toBe(true);
+    unblockUser(userId, commandType);
+    expect(isUserBlocked(userId, commandType)).toBe(false);
+  });
+
+  it("reset() réinitialise toutes les limitations", () => {
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit(userId, commandType);
+    }
+    rateLimiter.reset();
+    const stats = getRateLimitStats();
+    expect(stats.totalWindows).toBe(0);
+    expect(stats.totalBlocked).toBe(0);
+  });
+
+  it("getRateLimitStats retourne les stats correctes", () => {
+    checkRateLimit(userId, commandType);
+    const stats = getRateLimitStats();
+    expect(stats.totalWindows).toBeGreaterThanOrEqual(1);
+    expect(stats.commandStats[commandType]).toBeDefined();
+  });
+});

--- a/tests/core.retry.test.js
+++ b/tests/core.retry.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { RetryManager, retry } from "../core/utils/retry.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("RetryManager", () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = new RetryManager({
+      maxAttempts: 3,
+      baseDelay: 1,
+      maxDelay: 5,
+      jitter: false,
+    });
+    // Mock sleep pour accélérer les tests
+    vi.spyOn(manager, "sleep").mockImplementation(() => Promise.resolve());
+  });
+
+  it("exécute une opération qui réussit du premier coup", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const res = await manager.execute(op);
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("retry sur erreur retryable puis succès", async () => {
+    const error = new Error("ECONNRESET");
+    error.code = "ECONNRESET";
+    const op = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("ok");
+    const res = await manager.execute(op);
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it("lance une erreur après maxAttempts", async () => {
+    const error = new Error("ECONNRESET");
+    error.code = "ECONNRESET";
+    const op = vi.fn().mockRejectedValue(error);
+    await expect(manager.execute(op)).rejects.toThrow("ECONNRESET");
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it("ne retry pas sur erreur non-retryable", async () => {
+    const error = new Error("FATAL");
+    error.code = "FATAL";
+    const op = vi.fn().mockRejectedValue(error);
+    await expect(manager.execute(op)).rejects.toThrow("FATAL");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepte des options custom", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const res = await manager.execute(op, { maxAttempts: 2 });
+    expect(res).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retry (fonction utilitaire)", () => {
+  it("fonctionne comme prévu", async () => {
+    let count = 0;
+    const op = async () => {
+      count++;
+      if (count < 2)
+        throw Object.assign(new Error("ECONNRESET"), { code: "ECONNRESET" });
+      return "ok";
+    };
+    const res = await retry(op, {
+      maxAttempts: 3,
+      baseDelay: 1,
+      maxDelay: 5,
+      jitter: false,
+    });
+    expect(res).toBe("ok");
+  });
+});

--- a/tests/core.secureLogger.test.js
+++ b/tests/core.secureLogger.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { maskSensitiveData, secureLogger } from "../core/utils/secureLogger.js";
+
+// Mock du logger pour éviter les effets de bord
+vi.mock("../bot/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("secureLogger - maskSensitiveData", () => {
+  beforeEach(() => {
+    secureLogger.setSecurityLevel("medium");
+  });
+
+  it("masque les tokens", () => {
+    const msg = "token: 'abc12345678901234567890'";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[TOKEN_MASQUÉ]");
+  });
+
+  it("masque les emails", () => {
+    const msg = "Contact: test@example.com";
+    const masked = maskSensitiveData(msg, "medium", { maskEmails: true });
+    expect(masked).toContain("[EMAIL_MASQUÉ]");
+  });
+
+  it("masque les mots de passe", () => {
+    const msg = "password: 'supersecret'";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[MOT_DE_PASSE_MASQUÉ]");
+  });
+
+  it("masque les Discord IDs dans les contextes appropriés", () => {
+    const msg = "userId: 123456789012345678";
+    const masked = maskSensitiveData(msg, "medium", { maskIds: true });
+    expect(masked).toContain("[DISCORD_ID]");
+  });
+
+  it("ne masque pas les données non sensibles", () => {
+    const msg = "Ceci est un message normal.";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toBe(msg);
+  });
+
+  it("masque les URLs avec token", () => {
+    const msg = "https://example.com/api?token=abc123";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[URL_MASQUÉE]");
+  });
+
+  it("masque les IPs privées en production", () => {
+    // Simuler le contexte production
+    secureLogger.securityContext.isProduction = true;
+    const msg = "IP: 192.168.1.42";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[IP_MASQUÉE]");
+    // Reset
+    secureLogger.securityContext.isProduction = false;
+  });
+
+  it("masque les clés privées", () => {
+    const msg =
+      "-----BEGIN PRIVATE KEY-----\nABCDEF\n-----END PRIVATE KEY-----";
+    const masked = maskSensitiveData(msg);
+    expect(masked).toContain("[CLÉ_PRIVÉE_MASQUÉE]");
+  });
+});

--- a/tests/integration/loadCommands.test.js
+++ b/tests/integration/loadCommands.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+  },
+}));
+vi.mock("node:path", () => ({
+  default: {
+    join: vi.fn((...args) => args.join("/")),
+    dirname: vi.fn(() => "/fake/dir"),
+  },
+}));
+vi.mock("node:url", () => ({
+  pathToFileURL: vi.fn((p) => ({ href: `file://${p}` })),
+  fileURLToPath: vi.fn(() => "/fake/dir/loadCommands.js"),
+}));
+vi.mock("../logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    custom: vi.fn(),
+    section: vi.fn(),
+  },
+}));
+
+const importMock = vi.fn();
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+import logger from "../logger.js";
+import { loadCommands } from "../../bot/handlers/loadCommands.js";
+
+describe("loadCommands", () => {
+  let client;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = { commands: new Map() };
+  });
+
+  it("charge les commandes valides", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["ping.js"]);
+    importMock.mockResolvedValueOnce({
+      default: { data: { name: "ping" }, execute: vi.fn() },
+    });
+    const res = await loadCommands(client, importMock);
+    expect(res.loaded).toContain("ping");
+    expect(res.failed).toHaveLength(0);
+    expect(client.commands.has("ping")).toBe(true);
+  });
+
+  it("gère les commandes invalides", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["bad.js"]);
+    importMock.mockResolvedValueOnce({ default: {} });
+    const res = await loadCommands(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toContain("bad.js");
+  });
+
+  it("gère les erreurs d'import", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["fail.js"]);
+    importMock.mockRejectedValueOnce(new Error("fail"));
+    const res = await loadCommands(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toContain("fail.js");
+  });
+
+  it("gère le dossier manquant", async () => {
+    fs.default.existsSync.mockReturnValue(false);
+    const res = await loadCommands(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toHaveLength(0);
+    expect(res.total).toBe(0);
+  });
+});

--- a/tests/integration/loadEvents.test.js
+++ b/tests/integration/loadEvents.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+  },
+}));
+vi.mock("node:path", () => ({
+  default: {
+    join: vi.fn((...args) => args.join("/")),
+    dirname: vi.fn(() => "/fake/dir"),
+  },
+}));
+vi.mock("node:url", () => ({
+  pathToFileURL: vi.fn((p) => ({ href: `file://${p}` })),
+  fileURLToPath: vi.fn(() => "/fake/dir/loadEvents.js"),
+}));
+vi.mock("../logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    custom: vi.fn(),
+    section: vi.fn(),
+  },
+}));
+
+const importMock = vi.fn();
+import { loadEvents } from "../../bot/handlers/loadEvents.js";
+import * as fs from "node:fs";
+
+describe("loadEvents", () => {
+  let client;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = {
+      on: vi.fn(),
+      once: vi.fn(),
+    };
+  });
+
+  it("charge les events valides", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["ready.js"]);
+    importMock.mockResolvedValueOnce({
+      default: { name: "ready", execute: vi.fn(), once: false },
+    });
+    const res = await loadEvents(client, importMock);
+    expect(res.loaded).toContain("ready");
+    expect(res.failed).toHaveLength(0);
+    expect(client.on).toHaveBeenCalledWith("ready", expect.any(Function));
+  });
+
+  it("charge les events valides avec once", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["guildCreate.js"]);
+    importMock.mockResolvedValueOnce({
+      default: { name: "guildCreate", execute: vi.fn(), once: true },
+    });
+    const res = await loadEvents(client, importMock);
+    expect(res.loaded).toContain("guildCreate");
+    expect(res.failed).toHaveLength(0);
+    expect(client.once).toHaveBeenCalledWith(
+      "guildCreate",
+      expect.any(Function)
+    );
+  });
+
+  it("gère les events invalides", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["bad.js"]);
+    importMock.mockResolvedValueOnce({ default: {} });
+    const res = await loadEvents(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toContain("bad.js");
+  });
+
+  it("gère les erreurs d'import", async () => {
+    fs.default.existsSync.mockReturnValue(true);
+    fs.default.readdirSync.mockReturnValue(["fail.js"]);
+    importMock.mockRejectedValueOnce(new Error("fail"));
+    const res = await loadEvents(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toContain("fail.js");
+  });
+
+  it("gère le dossier manquant", async () => {
+    fs.default.existsSync.mockReturnValue(false);
+    const res = await loadEvents(client, importMock);
+    expect(res.loaded).toHaveLength(0);
+    expect(res.failed).toHaveLength(0);
+    expect(res.total).toBe(0);
+  });
+});

--- a/tests/integration/nowplaying.test.js
+++ b/tests/integration/nowplaying.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import nowplayingCommand from "../../bot/commands/nowplaying.js";
+import { MessageFlags } from "discord.js";
+import axios from "axios";
+
+vi.mock("axios");
+
+// Mock interaction
+let mockInteraction;
+
+beforeEach(() => {
+  mockInteraction = {
+    reply: vi.fn().mockResolvedValue(true),
+  };
+});
+
+describe("NowPlaying Command", () => {
+  it("affiche la chanson en cours si l’API répond correctement", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { icestats: { source: { title: "Test Song - Artist" } } },
+    });
+    await nowplayingCommand.execute(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      "🎶 Now playing: **Test Song - Artist**"
+    );
+  });
+
+  it('affiche "Aucune chanson en cours." si l’API ne retourne pas de titre', async () => {
+    axios.get.mockResolvedValueOnce({ data: { icestats: { source: {} } } });
+    await nowplayingCommand.execute(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      "🎶 Now playing: **Aucune chanson en cours.**"
+    );
+  });
+
+  it("affiche un message d’erreur si l’API est indisponible", async () => {
+    axios.get.mockRejectedValueOnce(new Error("Network error"));
+    await nowplayingCommand.execute(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      content: "❌ Impossible de récupérer la chanson actuelle.",
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it("gère un format de réponse inattendu", async () => {
+    axios.get.mockResolvedValueOnce({ data: null });
+    await nowplayingCommand.execute(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledWith(
+      "🎶 Now playing: **Aucune chanson en cours.**"
+    );
+  });
+});

--- a/tests/integration/ping.test.js
+++ b/tests/integration/ping.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import pingCommand from "../../bot/commands/ping.js";
+
+vi.mock("discord.js", () => ({
+  MessageFlags: { Ephemeral: 64 },
+  SlashCommandBuilder: class {
+    setName(name) {
+      this.name = name;
+      return this;
+    }
+    setDescription(description) {
+      this.description = description;
+      return this;
+    }
+    setDMPermission() {
+      return this;
+    }
+    setDefaultMemberPermissions() {
+      return this;
+    }
+  },
+}));
+
+describe("Ping Command", () => {
+  let mockInteraction;
+  let mockClient;
+
+  beforeEach(() => {
+    const now = Date.now();
+    mockInteraction = {
+      createdTimestamp: now,
+      reply: vi.fn().mockResolvedValue({ createdTimestamp: now + 50 }),
+      editReply: vi.fn().mockResolvedValue(true),
+      deferReply: vi.fn().mockResolvedValue(true),
+      followUp: vi.fn().mockResolvedValue(true),
+      replied: false,
+      deferred: false,
+      user: { id: "bot123", username: "TestBot", tag: "TestBot#1234" },
+      guilds: {
+        cache: new Map([
+          ["987654321", { id: "987654321", name: "Test Guild" }],
+        ]),
+      },
+      client: {
+        ws: {
+          ping: 25, // Ajout du ping ici, nécessaire pour la commande
+        },
+      },
+    };
+    mockClient = mockInteraction.client;
+  });
+
+  it("should execute ping command successfully", async () => {
+    await pingCommand.execute(mockInteraction);
+    expect(mockInteraction.reply).toHaveBeenCalledWith({
+      content: "Ping...",
+      fetchReply: true,
+    });
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("🏓 Pong !")
+    );
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("Latence bot:")
+    );
+    expect(mockInteraction.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("Latence API:")
+    );
+  });
+
+  it("should handle ping command errors gracefully", async () => {
+    mockInteraction.reply.mockRejectedValueOnce(new Error("Network error"));
+    const originalError = console.error;
+    console.error = vi.fn();
+    try {
+      await pingCommand.execute(mockInteraction);
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "❌ Erreur lors de la vérification de la latence.",
+        flags: expect.any(Number),
+      });
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/tests/integration/play.test.js
+++ b/tests/integration/play.test.js
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import playCommand from "../../bot/commands/play.js";
+import {
+  joinVoiceChannel,
+  createAudioPlayer,
+  createAudioResource,
+  AudioPlayerStatus,
+  NoSubscriberBehavior,
+} from "@discordjs/voice";
+import logger from "../../bot/logger.js";
+
+vi.mock("@discordjs/voice", () => ({
+  joinVoiceChannel: vi.fn(),
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  AudioPlayerStatus: { Playing: "playing" },
+  NoSubscriberBehavior: { Pause: "pause" },
+}));
+
+vi.mock("../../bot/logger.js", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("discord.js", () => ({
+  ChannelType: { GuildStageVoice: 13, GuildVoice: 2 },
+  MessageFlags: { Ephemeral: 64 },
+  SlashCommandBuilder: class {
+    setName(name) {
+      this.name = name;
+      return this;
+    }
+    setDescription(description) {
+      this.description = description;
+      return this;
+    }
+    setDMPermission() {
+      return this;
+    }
+    setDefaultMemberPermissions() {
+      return this;
+    }
+  },
+}));
+
+describe("Play Command", () => {
+  let mockInteraction;
+  let mockClient;
+
+  beforeEach(() => {
+    mockInteraction = {
+      commandName: "play",
+      user: { id: "123456789", username: "testuser" },
+      guild: { id: "987654321", name: "Test Guild" },
+      channel: { id: "111222333", name: "test-channel" },
+      createdTimestamp: Date.now(),
+      reply: vi.fn().mockResolvedValue({
+        createdTimestamp: Date.now() + 50,
+        editReply: vi.fn().mockResolvedValue(true),
+      }),
+      editReply: vi.fn().mockResolvedValue(true),
+      deferReply: vi.fn().mockResolvedValue(true),
+      followUp: vi.fn().mockResolvedValue(true),
+      replied: false,
+      deferred: false,
+      options: {
+        getString: vi.fn(),
+        getInteger: vi.fn(),
+        getBoolean: vi.fn(),
+        getSubcommand: vi.fn(),
+      },
+      member: {
+        voice: {
+          channel: {
+            id: "555555555",
+            name: "Voice Channel",
+            type: 13,
+            guild: {
+              id: "987654321",
+              voiceAdapterCreator: vi.fn(),
+            },
+          },
+        },
+      },
+    };
+    mockClient = {};
+    mockInteraction.client = mockClient;
+  });
+
+  it("should have correct command data structure", () => {
+    expect(playCommand).toHaveProperty("data");
+    expect(playCommand).toHaveProperty("execute");
+    expect(playCommand.data.name).toBe("play");
+    expect(playCommand.data.description).toBeDefined();
+  });
+
+  it("should handle play command with valid URL", async () => {
+    mockInteraction.options.getString.mockReturnValue(
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+    try {
+      await playCommand.execute(mockInteraction, mockClient);
+      expect(true).toBe(true);
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+
+  it("should handle play command with search query", async () => {
+    const playCommandMock = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        message: "Searching for: test song",
+      }),
+    };
+    mockInteraction.options.getString.mockReturnValue("test song");
+    await playCommandMock.execute(mockInteraction, mockClient);
+    expect(playCommandMock.execute).toHaveBeenCalledWith(
+      mockInteraction,
+      mockClient
+    );
+  });
+
+  describe("(erreurs)", () => {
+    it("retourne une erreur si l'utilisateur n'est pas dans un salon vocal", async () => {
+      const interaction = {
+        ...mockInteraction,
+        member: { voice: null },
+        reply: vi.fn(),
+      };
+      await playCommand.execute(interaction);
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("Tu dois être dans un salon vocal"),
+        })
+      );
+    });
+
+    it("retourne une erreur si le salon vocal nest pas un Stage Channel", async () => {
+      const interaction = {
+        ...mockInteraction,
+        member: { voice: { channel: { type: 2 } } }, // 2 = GuildVoice
+        reply: vi.fn(),
+      };
+      await playCommand.execute(interaction);
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining(
+            "Cette commande ne fonctionne que dans un Stage Channel"
+          ),
+        })
+      );
+    });
+
+    it("retourne une erreur si joinVoiceChannel échoue", async () => {
+      // Simule une erreur lors de la connexion vocale
+      joinVoiceChannel.mockImplementationOnce(() => {
+        throw new Error("Connexion échouée");
+      });
+      mockInteraction.deferred = true;
+      mockInteraction.editReply = vi.fn();
+      await playCommand.execute(mockInteraction);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("❌ Erreur exécution /play"),
+        expect.any(Error)
+      );
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining(
+            "❌ Une erreur est survenue pendant la tentative de lecture."
+          ),
+        })
+      );
+    });
+
+    it("retourne une erreur si createAudioResource échoue", async () => {
+      // Simule une connexion réussie
+      joinVoiceChannel.mockReturnValue({ subscribe: vi.fn() });
+      // Simule la création du player
+      createAudioPlayer.mockReturnValue({
+        play: vi.fn(),
+        once: vi.fn(),
+        on: vi.fn(),
+      });
+      // Simule une erreur lors de la création de la ressource audio
+      createAudioResource.mockImplementationOnce(() => {
+        throw new Error("Erreur ressource");
+      });
+      mockInteraction.deferred = true;
+      mockInteraction.editReply = vi.fn();
+      await playCommand.execute(mockInteraction);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("❌ Erreur exécution /play"),
+        expect.any(Error)
+      );
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining(
+            "❌ Une erreur est survenue pendant la tentative de lecture."
+          ),
+        })
+      );
+    });
+  });
+});

--- a/tests/integration/stop.test.js
+++ b/tests/integration/stop.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import stopCommand from "../../bot/commands/stop.js";
+
+vi.mock("discord.js", () => ({
+  SlashCommandBuilder: class {
+    setName(name) {
+      this.name = name;
+      return this;
+    }
+    setDescription(description) {
+      this.description = description;
+      return this;
+    }
+    setDMPermission() {
+      return this;
+    }
+    setDefaultMemberPermissions() {
+      return this;
+    }
+  },
+}));
+
+describe("Stop Command", () => {
+  let mockInteraction;
+  let mockClient;
+
+  beforeEach(() => {
+    mockInteraction = {
+      guildId: "guild123",
+      reply: vi.fn(),
+      client: {
+        voice: {
+          adapters: new Map([
+            [
+              "guild123",
+              {
+                destroy: vi.fn().mockResolvedValue(true),
+              },
+            ],
+          ]),
+        },
+      },
+    };
+    mockClient = mockInteraction.client;
+  });
+
+  it("should have correct command data structure", () => {
+    expect(stopCommand).toHaveProperty("data");
+    expect(stopCommand).toHaveProperty("execute");
+    expect(stopCommand.data.name).toBe("stop");
+    expect(stopCommand.data.description).toBeDefined();
+  });
+
+  it("should handle stop command", async () => {
+    try {
+      await stopCommand.execute(mockInteraction);
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.stringContaining("⏹️")
+      );
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## **✅ Ajout de tests unitaires pour les modules critiques**
Cette PR ajoute une couverture de tests unitaires pour les modules fondamentaux du bot :

- `AppState` : tests des getters, setters, état de santé, et reset.
- `rateLimiter` : tests des limites, blocage/déblocage, reset, et statistiques.
- `retry` : tests du comportement du retry manager (succès, retry, échec, options custom).
- `secureLogger` : tests du masquage des données sensibles (tokens, emails, mots de passe, Discord IDs, URLs, IPs privées, clés privées).

### Points clés :

- Mock du logger pour éviter les effets de bord dans tous les tests.
- Les tests accélèrent les cycles de dev et sécurisent les évolutions futures.
- La couverture porte sur les cas courants, limites et les principaux scénarios d’erreur.